### PR TITLE
Implement race reporting

### DIFF
--- a/GameSource/symbols.txt
+++ b/GameSource/symbols.txt
@@ -695,6 +695,9 @@ GetCurrent__9GameSceneFv = 0x8051bed0
 #RootScene
 sInstance__9RootScene = 0x809bd740
 
+#RaceScene
+UpdateRaceInstances__9RaceSceneFv = 0x80554ad4
+
 ##GHOSTS
 #RKG
 ClearBuffer__3RKGFv = 0x8051c088

--- a/PulsarEngine/Race/RaceReporting.cpp
+++ b/PulsarEngine/Race/RaceReporting.cpp
@@ -1,0 +1,117 @@
+#include <MarioKartWii/Scene/RaceScene.hpp>
+#include <MarioKartWii/Race/RaceInfo/RaceInfo.hpp>
+#include <MarioKartWii/Driver/DriverManager.hpp>
+#include <MarioKartWii/RKNet/RKNetController.hpp>
+#include <Network/GPReport.hpp>
+
+namespace Pulsar {
+
+RaceStage sLastRaceStage = RACESTAGE_RACE;
+
+void UpdateRaceInstances() {
+    RaceScene::UpdateRaceInstances();
+    if (!DriverMgr::isOnlineRace)
+        return;
+
+    Raceinfo* raceInfo = Raceinfo::sInstance;
+    if (!raceInfo)
+        return;
+
+    if (raceInfo->stage != sLastRaceStage) {
+        sLastRaceStage = raceInfo->stage;
+        // OS::Report("================================\n");
+        // OS::Report("Race stage: %d\n", sLastRaceStage);
+        // OS::Report("================================\n");
+        if (sLastRaceStage == RACESTAGE_FINISHED) {
+            Network::ReportU32("wl:mkw_race_stage", sLastRaceStage);
+        }
+    }
+}
+
+void EndPlayerRaceHook(Raceinfo* _this, u8 playerIdx) {
+    _this->EndPlayerRace(playerIdx);
+    if (!DriverMgr::isOnlineRace)
+        return;
+
+    Racedata* raceData = Racedata::sInstance;
+    if (!raceData)
+        return;
+
+    RacedataPlayer* racePlayer = &raceData->racesScenario.players[playerIdx];
+    if (racePlayer->playerType == PLAYER_REAL_LOCAL) {
+        RKNet::Controller* netController = RKNet::Controller::sInstance;
+        RKNet::ControllerSub& sub = netController->subs[netController->currentSub];
+
+        s8 hostPlayerIdx = -1;
+        for (int i = 0; i < raceData->racesScenario.playerCount; i++) {
+            if (netController->aidsBelongingToPlayerIds[i] == sub.hostAid) {
+                hostPlayerIdx = i;
+                break;
+            }
+        }
+
+        // If the host could not be found, return immediately
+        if (hostPlayerIdx == -1)
+            return;
+
+        // You have dc'd from the host (or the host dc'd), crying cat emoji.
+        //
+        // If less than half the room finished, do not report. It's likely a win dc.
+        // If 3 or more people disconnected in a single race, do not report.
+        if (_this->players[hostPlayerIdx]->stateFlags & 0x10) {
+            u8 finishedCount = 0;
+            u8 disconnectCount = 0;
+            for (int i = 0; i < raceData->racesScenario.playerCount; i++) {
+                if (_this->players[i]->stateFlags & 0x10) {
+                    disconnectCount++;
+                } else if (_this->players[i]->stateFlags & 0x02) {
+                    finishedCount++;
+                }
+            }
+
+            if (finishedCount <= (raceData->racesScenario.playerCount / 2))
+                return;
+
+            if (disconnectCount >= 3)
+                return;
+        }
+
+        Timer* finishTime = _this->players[playerIdx]->raceFinishTime;
+        float time = (finishTime->minutes * 60.0f) + (finishTime->seconds) + (finishTime->milliseconds / 1000.0f);
+
+        char buffer[128];
+        snprintf(buffer,
+                 sizeof(buffer),
+                 "hi=%d|ch=%d|ve=%d|ft=%u|fp=%d|f1=%u|pc=%d",
+                 racePlayer->hudSlotId,
+                 racePlayer->characterId,
+                 racePlayer->kartId,
+                 *(u32*)&time,
+                 racePlayer->finishPos,
+                 _this->players[playerIdx]->framesInFirst,
+                 raceData->racesScenario.playerCount);
+
+        Network::Report("wl:mkw_race_result", buffer);
+    }
+}
+
+kmCall(0x80554eec, UpdateRaceInstances);
+kmCall(0x8053491c, EndPlayerRaceHook);
+
+// No sit DC [Bully]
+//
+// For testing purposes
+/*
+04521408 38000000
+0453EC94 38000000
+0453EF6C 38000000
+0453F0B4 38000000
+0453F124 38000000
+*/
+// kmWrite32(0x80521408, 0x38000000);
+// kmWrite32(0x8053ec94, 0x38000000);
+// kmWrite32(0x8053ef6c, 0x38000000);
+// kmWrite32(0x8053f0b4, 0x38000000);
+// kmWrite32(0x8053f124, 0x38000000);
+
+}  // namespace Pulsar

--- a/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamSelect.hpp
+++ b/PulsarEngine/UI/ExtendedTeamSelect/ExtendedTeamSelect.hpp
@@ -18,6 +18,7 @@ class ExtendedTeamSelect : public Pages::MenuInteractable {
 
     void OnInit() override;
     void BeforeEntranceAnimations() override;
+    void BeforeExitAnimations() override;
     void BeforeControlUpdate() override;
     void AfterControlUpdate() override;
     void OnResume() override;


### PR DESCRIPTION
This implements the following:

- Reporting of the stage of the race (to be used to make sure race are being reported on time)
- Reporting of the extended teams the client belongs to on friend room start 
- Reporting of the finish times, character combo and a couple other stats.

They should support splitscreen multiplayer, I think.

I tested in friend rooms with and without Extended Teams to no issue, also in worldwides.

This is to be coupled with the RWFC server Pull Request to implement the feature server-side.