### PR TITLE
Add back button click handlers to settings UI

### DIFF
--- a/PulsarEngine/Settings/UI/SettingsPageSelect.cpp
+++ b/PulsarEngine/Settings/UI/SettingsPageSelect.cpp
@@ -44,6 +44,8 @@ SettingsPageSelect::SettingsPageSelect() {
     onButtonDeselectHandler.ptmf = &SettingsPageSelect::OnButtonDeselect;
     onBackPressHandler.subject = this;
     onBackPressHandler.ptmf = &SettingsPageSelect::OnBackPress;
+    onBackButtonClickHandler.subject = this;
+    onBackButtonClickHandler.ptmf = &SettingsPageSelect::OnBackButtonClick;
 
     this->controlsManipulatorManager.Init(1, false);
     this->SetManipulatorManager(controlsManipulatorManager);
@@ -53,6 +55,7 @@ SettingsPageSelect::SettingsPageSelect() {
 void SettingsPageSelect::OnInit() {
     MenuInteractable::OnInit();
     this->SetTransitionSound(0, 0);
+    this->backButton.SetOnClickHandler(this->onBackButtonClickHandler, 0);
 }
 
 UIControl* SettingsPageSelect::CreateControl(u32 id) {
@@ -153,9 +156,12 @@ ManipulatorManager& SettingsPageSelect::GetManipulatorManager() {
 }
 
 void SettingsPageSelect::OnBackPress(u32 hudSlotId) {
-    PushButton& firstButton = this->pageButtons[0];
-    firstButton.SelectFocus();
-    this->LoadPrevPage(firstButton);
+    this->backButton.SelectFocus();
+    this->LoadPrevPage(this->backButton);
+}
+
+void SettingsPageSelect::OnBackButtonClick(PushButton& button, u32 hudSlotId) {
+    this->OnBackPress(hudSlotId);
 }
 
 void SettingsPageSelect::OnButtonClick(PushButton& button, u32 hudSlotId) {

--- a/PulsarEngine/Settings/UI/SettingsPageSelect.hpp
+++ b/PulsarEngine/Settings/UI/SettingsPageSelect.hpp
@@ -34,11 +34,14 @@ class SettingsPageSelect : public Pages::MenuInteractable {
     void BeforeControlUpdate() override;
 
     void OnBackPress(u32 hudSlotId);
+    void OnBackButtonClick(PushButton& button, u32 hudSlotId);
 
    private:
     void OnButtonClick(PushButton& button, u32 hudSlotId);
     void OnButtonSelect(PushButton& button, u32 hudSlotId);
     void OnButtonDeselect(PushButton& button, u32 hudSlotId) {}
+
+    PtmfHolder_2A<SettingsPageSelect, void, PushButton&, u32> onBackButtonClickHandler;
 
     // Buttons for each settings page - max 12 pages
     PushButton pageButtons[Settings::Params::pageCount];

--- a/PulsarEngine/Settings/UI/SettingsPanel.cpp
+++ b/PulsarEngine/Settings/UI/SettingsPanel.cpp
@@ -21,7 +21,7 @@ SettingsPanel::SettingsPanel() {
     catIdx = 0;
     externControlCount = 1;  // Only save button, no left/right navigation
     internControlCount = Settings::Params::maxRadioCount + Settings::Params::maxScrollerCount;
-    hasBackButton = false;
+    hasBackButton = true;
     nextPageId = static_cast<PageId>(id);
     // titleBmg = BMG_SETTINGS_TITLE;
     activePlayerBitfield = 1;
@@ -61,6 +61,8 @@ SettingsPanel::SettingsPanel() {
     onButtonDeselectHandler.ptmf = &Pages::VSSettings::OnButtonDeselect;
     onBackPressHandler.subject = this;
     onBackPressHandler.ptmf = &SettingsPanel::OnBackPress;
+    onBackButtonClickHandler.subject = this;
+    onBackButtonClickHandler.ptmf = &SettingsPanel::OnBackButtonClick;
     onStartPressHandler.subject = this;
     onStartPressHandler.ptmf = &MenuInteractable::HandleStartPress;
 
@@ -90,6 +92,8 @@ void SettingsPanel::OnInit() {
     // radioButtonControls = new RadioButtonControl[this->radioCount];
     // upDownControls = new UpDownControl[this->scrollersCount];
     // textUpDown = new TextUpDownValueControl[this->scrollersCount];
+
+    this->backButton.SetOnClickHandler(this->onBackButtonClickHandler, 0);
 
     const Settings::Mgr& settings = Settings::Mgr::Get();
     for (int i = 0; i < Settings::Params::pageCount; ++i) {
@@ -321,14 +325,16 @@ void SettingsPanel::OnBackPress(u32 hudSlotId) {
         messageBox->Reset();
         messageBox->SetMessageWindowText(BMG_LANGUAGE_RESET_REQUIRED, nullptr);
         this->AddPageLayer(PAGE_MESSAGE_BOX_TRANSPARENT, 0);
-        PushButton& okButton = *this->externControls[0];
-        okButton.SelectFocus();
-        this->LoadPrevMenuAndSaveSettings(okButton);
+        this->backButton.SelectFocus();
+        this->LoadPrevMenuAndSaveSettings(this->backButton);
         return;
     }
-    PushButton& okButton = *this->externControls[0];
-    okButton.SelectFocus();
-    this->LoadPrevMenuAndSaveSettings(okButton);
+    this->backButton.SelectFocus();
+    this->LoadPrevMenuAndSaveSettings(this->backButton);
+}
+
+void SettingsPanel::OnBackButtonClick(PushButton& button, u32 hudSlotId) {
+    this->OnBackPress(hudSlotId);
 }
 
 void SettingsPanel::OnSaveButtonClick(PushButton& button, u32 hudSlotId) {

--- a/PulsarEngine/Settings/UI/SettingsPanel.hpp
+++ b/PulsarEngine/Settings/UI/SettingsPanel.hpp
@@ -43,6 +43,7 @@ class SettingsPanel : public Pages::MenuInteractable {
     UIControl* CreateControl(u32 id) override;  // 0x88
     void SetButtonHandlers(PushButton& pushButton) override;  // 80853aac 0x8C
     void OnBackPress(u32 hudSlotId);
+    void OnBackButtonClick(PushButton& button, u32 hudSlotId);
     void BeforeControlUpdate() override;
 
    private:
@@ -79,6 +80,7 @@ class SettingsPanel : public Pages::MenuInteractable {
     // u32 scrollersCount; //0x72c
     PtmfHolder_2A<MenuInteractable, void, PushButton&, u32> onRightButtonClickHandler;  // 0x738
     PtmfHolder_2A<MenuInteractable, void, PushButton&, u32> onLeftButtonClickHandler;  // 0x74c
+    PtmfHolder_2A<SettingsPanel, void, PushButton&, u32> onBackButtonClickHandler;
 
     u8 radioSettings[Settings::Params::pageCount][Settings::Params::maxRadioCount];
     u8 scrollerSettings[Settings::Params::pageCount][Settings::Params::maxScrollerCount];


### PR DESCRIPTION
Introduced dedicated OnBackButtonClick handlers for both SettingsPageSelect and SettingsPanel, wiring them to the back button's click event. Updated back navigation logic to use the back button directly, improving consistency and maintainability of back navigation in the settings UI.