### PR TITLE
Fix null pointer check in course selection

### DIFF
--- a/PulsarEngine/SlotExpansion/UI/ExpansionUIMisc.cpp
+++ b/PulsarEngine/SlotExpansion/UI/ExpansionUIMisc.cpp
@@ -522,7 +522,9 @@ static void ExtCourseSelectCourseInitSelf(CtrlMenuCourseSelectCourse* course) {
             toSelect = &curButton;
         }
     };
-    coursePage->SelectButton(*toSelect);
+    if (coursePage != nullptr) {
+        coursePage->SelectButton(*toSelect);
+    }
 };
 kmWritePointer(0x808d30d8, ExtCourseSelectCourseInitSelf);  // 807e5118
 


### PR DESCRIPTION
Added a nullptr check before calling SelectButton on coursePage to prevent potential crashes when coursePage is not initialized.