### PR TITLE
Add Wrkus ID to PRIORITY_BADGE_FC_LIST

### DIFF
--- a/PulsarEngine/Network/Ranking.cpp
+++ b/PulsarEngine/Network/Ranking.cpp
@@ -47,6 +47,7 @@ static const u64 PRIORITY_BADGE_FC_LIST[] = {
     421507127201ULL,  // Jacher
     800580ULL,  // Rambo
     81604380197ULL,  // Patchzy
+    400032268799ULL,  // Wrkus
     0ULL};
 
 // FOR THE COLONY


### PR DESCRIPTION
Insert Wrkus (400032268799ULL) into the PRIORITY_BADGE_FC_LIST array in PulsarEngine/Network/Ranking.cpp so Wrkus is included in the priority badge FC list.