### PR TITLE
Fix matchmaking timeout condition

### DIFF
--- a/PulsarEngine/Network/Matchmaking.cpp
+++ b/PulsarEngine/Network/Matchmaking.cpp
@@ -85,7 +85,7 @@ void CustomRandomizeServers() {
         Settings::SETTINGSTYPE_ONLINE,
         SCROLLER_MATCHMAKINGTIMEOUT);
     const bool isMatchmakingTimeoutEnabled =
-        (timeoutSetting != MATCHMAKINGTIMEOUT_INFINITE);
+        (timeoutSetting == MATCHMAKINGTIMEOUT_INFINITE);
     const int smallRoomPenalty = 1000000;
 
     if (joinAttempts < 3) {


### PR DESCRIPTION
Correct the conditional in PulsarEngine/Network/Matchmaking.cpp so isMatchmakingTimeoutEnabled uses 'timeoutSetting == MATCHMAKINGTIMEOUT_INFINITE' instead of '!=', fixing an inverted boolean that caused the timeout-enabled flag to be set incorrectly.