### PR TITLE
New channel bugfixes around My Stuff

### DIFF
--- a/PulsarEngine/PulsarSystem.cpp
+++ b/PulsarEngine/PulsarSystem.cpp
@@ -93,7 +93,7 @@ void System::Init(const ConfigFile& confRT, const ConfigFile& confCT, const Conf
         type = IOType_RIIVO;
         IOS::Close(ret);
     } else if (IsNewChannel() && !isDolphin) {
-        NewChannel_SetLoadedFromRRFlag();
+        NewChannel_Init();
         type = IOType_SD;
     } else {
         ret = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);

--- a/PulsarEngine/RetroRewindChannel.cpp
+++ b/PulsarEngine/RetroRewindChannel.cpp
@@ -1,4 +1,5 @@
 #include <PulsarSystem.hpp>
+#include "Debug/Debug.hpp"
 #include "RetroRewindChannel.hpp"
 
 namespace Pulsar {
@@ -8,7 +9,7 @@ bool IsNewChannel() {
 }
 
 bool NewChannel_UseSeparateSavegame() {
-    return *reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) & RRC_BITFLAG_SEPARATE_SAVEGAME == RRC_BITFLAG_SEPARATE_SAVEGAME;
+    return (*reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) & RRC_BITFLAG_SEPARATE_SAVEGAME) == RRC_BITFLAG_SEPARATE_SAVEGAME;
 }
 
 void NewChannel_SetLoadedFromRRFlag() {
@@ -17,6 +18,21 @@ void NewChannel_SetLoadedFromRRFlag() {
 
 void NewChannel_SetCrashFlag() {
     *reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) |= RRC_BITFLAG_RR_CRASHED;
+}
+
+void NewChannel_Init() {
+    u32 channelVersion = *reinterpret_cast<u32*>(RRC_ABI_VERSION_ADDRESS);
+    u32 requiredVersion = RRC_ABI_VERSION;
+
+    // Make sure the channel is compatible with this Code.pul
+    if (channelVersion != requiredVersion) {
+        char message[256];
+        snprintf(message, sizeof(message), "This version of Retro Rewind is incompatible with the version of the channel (abi%d != abi%d).\n"
+            "You can usually fix this by updating both RR and the channel to the latest version.", channelVersion, requiredVersion);
+        Debug::FatalError(message);
+    }
+
+    NewChannel_SetLoadedFromRRFlag();
 }
 
 }  // namespace Pulsar

--- a/PulsarEngine/RetroRewindChannel.hpp
+++ b/PulsarEngine/RetroRewindChannel.hpp
@@ -1,11 +1,19 @@
 #ifndef _RETRO_REWIND_CHANNEL_
 #define _RETRO_REWIND_CHANNEL_
 
+#include <kamek.hpp>
+
 namespace Pulsar {
 
 // Signature written by the new launcher.
 #define RRC_SIGNATURE_ADDRESS 0x817ffff8
+#define RRC_ABI_VERSION_ADDRESS 0x817ffffc
 #define RRC_SIGNATURE 0xDEADBEEF
+
+// The "ABI version" of the new channel; incremented each time a change is necessary that would break compatibility
+// (for example moving addresses of fixed data elsewhere).
+// This needs to match the version declared on the channel side, or otherwise an error is shown.
+#define RRC_ABI_VERSION 1
 
 // IMPORTANT: Always keep these bitflags in sync with the channel's code when adding new ones so they don't conflict!
 #define RRC_BITFLAGS_ADDRESS 0x817ffff0
@@ -19,6 +27,7 @@ bool NewChannel_UseSeparateSavegame();
 void NewChannel_SetLoadedFromRRFlag();
 // This loads the channels' crash handler if set and the channel is called back into.
 void NewChannel_SetCrashFlag();
+void NewChannel_Init();
 
 }  // namespace Pulsar
 


### PR DESCRIPTION
This does two things (only relevant for the new channel in any case):

- Main change: in the new channel we *used* to write a signature at 0x93400100 (so RR can identify the new channel). This address was a bad choice because it basically wastes 2 MB of mem2 (and runs into OOM crashes), since we need to reserve everything above that address too even though we basically don't use mem2 at all. This PR moves that away to the very top of mem1, which is already reserved for a bunch of stuff in the new channel anyway

- Second change: Add a small "ABI version check", basically an int that we can increment on both sides whenever we need to make a change like this that breaks compatibility and it'll show a nice error when there's a mismatch (rather than random weirdness happening). This should be rather rare though


Whenever this gets merged and the Code.pul released, a new version of the channel needs to be released together too