### PR TITLE
Fix WiiLink licensing attribution

### DIFF
--- a/PulsarEngine/Network/GPReport.cpp
+++ b/PulsarEngine/Network/GPReport.cpp
@@ -1,3 +1,11 @@
+/*
+    Based on wfc-patcher-wii
+    Written by mkwcat
+
+    Copyright (c) 2023-2025 WiiLink
+    SPDX-License-Identifier: gpl-2.0-or-later
+*/
+
 #include <types.hpp>
 #include <include/c_stdio.h>
 #include <core/GS/GP/GPTypes.hpp>

--- a/PulsarEngine/Network/GPReport.hpp
+++ b/PulsarEngine/Network/GPReport.hpp
@@ -1,3 +1,11 @@
+/*
+    Based on wfc-patcher-wii
+    Written by mkwcat
+
+    Copyright (c) 2023-2025 WiiLink
+    SPDX-License-Identifier: gpl-2.0-or-later
+*/
+
 #ifndef _GPREPORT_
 #define _GPREPORT_
 #include <types.hpp>

--- a/PulsarEngine/Network/WiiLink.cpp
+++ b/PulsarEngine/Network/WiiLink.cpp
@@ -1,3 +1,11 @@
+/*
+    Based on wfc-patcher-wii
+    Written by mkwcat
+
+    Copyright (c) 2023-2025 WiiLink
+    SPDX-License-Identifier: gpl-2.0-or-later
+*/
+
 #include <Network/RSA.hpp>
 #include <Network/SHA256.hpp>
 #include <Network/WiiLink.hpp>

--- a/PulsarEngine/Network/WiiLink.hpp
+++ b/PulsarEngine/Network/WiiLink.hpp
@@ -1,3 +1,11 @@
+/*
+    Based on wfc-patcher-wii
+    Written by mkwcat
+
+    Copyright (c) 2023-2025 WiiLink
+    SPDX-License-Identifier: gpl-2.0-or-later
+*/
+
 #include <kamek.hpp>
 #include <Network/SHA256.hpp>
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ All source code in this repository is licensed under AGPLv3. This includes all f
 
 We borrow features from mkw-sp under MIT, specifically the Input Viewer. mkw-sp can be found under the MIT license in [mkw-sp](https://github.com/mkw-sp/mkw-sp); see LICENSE_mkw-sp for more information.
 
+Additionally, we borrow features from [wfc-patcher-wii](https://github.com/WiiLink24/wfc-patcher-wii), sublicensed under the [GPLv3](https://github.com/WiiLink24/wfc-patcher-wii/tree/main?tab=readme-ov-file#license). See LICENSE for more information.
+
 Pulsar is licensed under MIT. Pulsar can be found under the MIT license in [Pulsar](https://github.com/MelgMKW/Pulsar); see LICENSE_pulsar for more information.
 
 **NOTE:** You can ask to be fully exempted from these licensing constraints, feel free to contact the code author(s).


### PR DESCRIPTION
Adds attribution to WiiLink/wfc-patcher-wii source files, and amends this information to the README. Needs explicit signoff from @mkwcat before merge.