### PR TITLE
Use ephemeral files for crashes and loaded from rr for new channel

### DIFF
--- a/PulsarEngine/Debug/ExceptionHandler.cpp
+++ b/PulsarEngine/Debug/ExceptionHandler.cpp
@@ -11,6 +11,7 @@
 #include <PulsarSystem.hpp>
 #include <IO/IO.hpp>
 #include <RetroRewindChannel.hpp>
+#include <Dolphin/DolphinIOS.hpp>
 
 namespace Pulsar {
 namespace Debug {
@@ -30,6 +31,12 @@ void FatalError(const char* string) {
 #pragma suppress_warnings on
 void LaunchSoftware() {
     // If dolphin, restarts game, else launches Retro Rewind Channel->HBC->OHBC->WiiMenu
+    bool isDolphin = Dolphin::IsEmulator();
+
+    if (isDolphin) {
+        SystemManager::Shutdown();
+        return;
+    }
 
     s32 result = IO::OpenFix("/title/00010001/57524554/content/title.tmd\0", IOS::MODE_NONE);  // Retro Rewind Channel
     if (result >= 0) {
@@ -47,12 +54,6 @@ void LaunchSoftware() {
     if (result >= 0) {
         ISFS::Close(result);
         OS::__LaunchTitle(0x00010001, 0x48424330);
-        return;
-    }
-    result = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);
-    if (result >= 0 && !IsNewChannel()) {
-        IOS::Close(result);
-        SystemManager::Shutdown();
         return;
     }
     OS::__LaunchTitle(0x1, 0x2);  // Launch Wii Menu if channel isn't found
@@ -116,11 +117,11 @@ static void WriteHeaderCrash(u16 error, const OS::Context* context, u32 dsisr, u
     exception.displayedInfo = 0x23;
     exception.callbackArgs = nullptr;
 
-    if (IsNewChannel()) {
+    if (IsNewChannel() && !Dolphin::IsEmulator()) {
         // just "hide" the console/xfb
         db::DirectPrint_ChangeXfb((void*)0, 0, 0);
         // we just set the flag, generate dump file and return to the channel
-        NewChannel_SetCrashFlag();
+        NewChannel_WriteCrashEphFile();
     } else {
         db::Exception_Printf_("Saving Crash.pul and exiting...\n");
         db::PrintContext_(error, context, dsisr, dar);

--- a/PulsarEngine/PulsarSystem.cpp
+++ b/PulsarEngine/PulsarSystem.cpp
@@ -93,14 +93,9 @@ void System::Init(const ConfigFile& confRT, const ConfigFile& confCT, const Conf
         type = IOType_RIIVO;
         IOS::Close(ret);
     } else if (IsNewChannel() && !isDolphin) {
-        NewChannel_Init();
         type = IOType_SD;
-    } else {
-        ret = IO::OpenFix("/dev/dolphin", IOS::MODE_NONE);
-        if (isDolphin) {
-            type = IOType_DOLPHIN;
-            IOS::Close(ret);
-        }
+    } else if (isDolphin) {
+        type = IOType_DOLPHIN;
     }
 
     if (ShouldForceNandIoSaves()) {
@@ -119,6 +114,10 @@ void System::Init(const ConfigFile& confRT, const ConfigFile& confCT, const Conf
     this->info.Init(confRT.GetSection<InfoHolder>().info);
     this->InitIO(type);
     this->InitSettings(&CupsConfig::sInstance->trophyCount[0]);
+
+    if(IsNewChannel()) {
+        NewChannel_Init();
+    }
 
     u32 rtTrackCount = rtCups.ctsCupCount * 4;
     u32 ctTrackCount = ctCups.ctsCupCount * 4;

--- a/PulsarEngine/RetroRewindChannel.cpp
+++ b/PulsarEngine/RetroRewindChannel.cpp
@@ -1,6 +1,8 @@
 #include <PulsarSystem.hpp>
 #include "Debug/Debug.hpp"
 #include "RetroRewindChannel.hpp"
+#include "IO/SDIO.hpp"
+#include <Dolphin/DolphinIOS.hpp>
 
 namespace Pulsar {
 
@@ -12,12 +14,17 @@ bool NewChannel_UseSeparateSavegame() {
     return (*reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) & RRC_BITFLAG_SEPARATE_SAVEGAME) == RRC_BITFLAG_SEPARATE_SAVEGAME;
 }
 
-void NewChannel_SetLoadedFromRRFlag() {
-    *reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) |= RRC_BITFLAG_LOADED_FROM_RR;
+void NewChannel_WriteLoadedFromRREphFile() {
+    if(IO::sInstance == nullptr) return;
+    IO::sInstance->CreateAndOpen(RRC_LOADED_FROM_RR_EPH_FILE_PATH, IOS::MODE_NONE);
+    IO::sInstance->Close();
 }
 
-void NewChannel_SetCrashFlag() {
-    *reinterpret_cast<u8*>(RRC_BITFLAGS_ADDRESS) |= RRC_BITFLAG_RR_CRASHED;
+void NewChannel_WriteCrashEphFile() {
+    if(IO::sInstance == nullptr) return;
+    OS::Report("* NewChannel: Writing crash eph file\n");
+    IO::sInstance->CreateAndOpen(RRC_CRASH_EPH_FILE_PATH, IOS::MODE_NONE);
+    IO::sInstance->Close();
 }
 
 void NewChannel_Init() {
@@ -32,7 +39,9 @@ void NewChannel_Init() {
         Debug::FatalError(message);
     }
 
-    NewChannel_SetLoadedFromRRFlag();
+    if(!Dolphin::IsEmulator()) {
+        NewChannel_WriteLoadedFromRREphFile();
+    }
 }
 
 }  // namespace Pulsar

--- a/PulsarEngine/RetroRewindChannel.hpp
+++ b/PulsarEngine/RetroRewindChannel.hpp
@@ -18,15 +18,14 @@ namespace Pulsar {
 // IMPORTANT: Always keep these bitflags in sync with the channel's code when adding new ones so they don't conflict!
 #define RRC_BITFLAGS_ADDRESS 0x817ffff0
 #define RRC_BITFLAG_SEPARATE_SAVEGAME 0x1
-#define RRC_BITFLAG_LOADED_FROM_RR 0x2
-#define RRC_BITFLAG_RR_CRASHED 0x4
+
+#define RRC_LOADED_FROM_RR_EPH_FILE_PATH "/RetroRewindChannel/.lfrr"
+#define RRC_CRASH_EPH_FILE_PATH "/RetroRewindChannel/.crash"
 
 bool IsNewChannel();
 bool NewChannel_UseSeparateSavegame();
-// If we call back into the channel, this flag indicates to skip some steps in the channel.
-void NewChannel_SetLoadedFromRRFlag();
-// This loads the channels' crash handler if set and the channel is called back into.
-void NewChannel_SetCrashFlag();
+void NewChannel_WriteLoadedFromRREphFile();
+void NewChannel_WriteCrashEphFile();
 void NewChannel_Init();
 
 }  // namespace Pulsar


### PR DESCRIPTION
Since memory is wiped when launching the channel from in-game, use ephemeral (temporary) files to store critical state, such as launching after a crash.