### PR TITLE
Adjust loss cap for ratings <= 150

### DIFF
--- a/PulsarEngine/Network/Rating/PlayerRating.cpp
+++ b/PulsarEngine/Network/Rating/PlayerRating.cpp
@@ -82,7 +82,7 @@ static float GetGainCap(float rating) {
 
 static float GetLossCap(float rating) {
     if (rating >= 500.0f) return -2.09f;
-    if (rating <= 150.0f) return -2.09f;
+    if (rating <= 150.0f) return -0.5f;
     float t = (rating - 150.0f) / 350.0f;
     return -0.5f + (-2.09f + 0.5f) * t;
 }


### PR DESCRIPTION
Change GetLossCap lower bound for very low ratings: for rating <= 150 the function now returns -0.5f instead of -2.09f. This corrects the extreme negative cap applied to low-rated players while leaving the interpolation logic for intermediate ratings unchanged.