### PR TITLE
Fix /RetroRewindChannel/.lfrr write

### DIFF
--- a/PulsarEngine/RetroRewindChannel.cpp
+++ b/PulsarEngine/RetroRewindChannel.cpp
@@ -16,13 +16,18 @@ bool NewChannel_UseSeparateSavegame() {
 
 void NewChannel_WriteLoadedFromRREphFile() {
     if(IO::sInstance == nullptr) return;
-    IO::sInstance->CreateAndOpen(RRC_LOADED_FROM_RR_EPH_FILE_PATH, IOS::MODE_NONE);
+    IO::sInstance->CreateAndOpen(RRC_LOADED_FROM_RR_EPH_FILE_PATH, IOS::MODE_READ_WRITE);
     IO::sInstance->Close();
+    // Check the file was actually written
+    // Also for some reason without this it doesnt get wrtten. I guess there's some flush/sync issues
+    if (!IO::sInstance->OpenFile(RRC_LOADED_FROM_RR_EPH_FILE_PATH, IOS::MODE_READ)) {
+        Debug::FatalError(RRC_LOADED_FROM_RR_EPH_FILE_PATH " was not written properly.");
+    }
 }
 
 void NewChannel_WriteCrashEphFile() {
     if (IO::sInstance == nullptr) return;
-    IO::sInstance->CreateAndOpen(RRC_CRASH_EPH_FILE_PATH, IOS::MODE_NONE);
+    IO::sInstance->CreateAndOpen(RRC_CRASH_EPH_FILE_PATH, IOS::MODE_READ_WRITE);
     IO::sInstance->Close();
 }
 
@@ -36,10 +41,6 @@ void NewChannel_Init() {
         snprintf(message, sizeof(message), "This version of Retro Rewind is incompatible with the version of the channel (abi%d != abi%d).\n"
             "You can usually fix this by updating both RR and the channel to the latest version.", channelVersion, requiredVersion);
         Debug::FatalError(message);
-    }
-
-    if (!Dolphin::IsEmulator()) {
-        NewChannel_WriteLoadedFromRREphFile();
     }
 }
 

--- a/PulsarEngine/UI/MiscUI.cpp
+++ b/PulsarEngine/UI/MiscUI.cpp
@@ -14,6 +14,7 @@
 #include <Dolphin/DolphinIOS.hpp>
 #include <Gamemodes/LapKO/LapKOMgr.hpp>
 #include <UI/UI.hpp>
+#include <RetroRewindChannel.hpp>
 
 namespace Pulsar {
 
@@ -45,10 +46,15 @@ kmBranch(0x80646754, AfterWifiResults);
 // Credit to Kazuki for making the original ASM code, and Brawlbox for porting it to C++
 static void LaunchRiivolutionButton(SectionMgr* sectionMgr) {
     const SectionId id = sectionMgr->nextSectionId;
-    if (id == SECTION_CHANNEL_FROM_MENU || id == SECTION_CHANNEL_FROM_CHECK_RANKINGS || id == SECTION_CHANNEL_FROM_DOWNLOADS)
+    if (id == SECTION_CHANNEL_FROM_MENU || id == SECTION_CHANNEL_FROM_CHECK_RANKINGS || id == SECTION_CHANNEL_FROM_DOWNLOADS) {
+        if(!Dolphin::IsEmulator() && IsNewChannel()) {
+            NewChannel_WriteLoadedFromRREphFile();
+        }
+
         Debug::LaunchSoftware();
-    else
+    } else {
         sectionMgr->LoadSection();
+    }
 }
 kmCall(0x80553a60, LaunchRiivolutionButton);
 


### PR DESCRIPTION
Before, this file would be written whenever you load the game with the RR channel, but this is incorrect. This fixes the behaviour to only make this file if the Retro Rewind Channel button was pressed. This causes the channel to skip the auto-launch sequence.