### PR TITLE
Remove bin verification from compilation on test builds

### DIFF
--- a/PulsarEngine/Race/BinLoader.cpp
+++ b/PulsarEngine/Race/BinLoader.cpp
@@ -2,14 +2,14 @@
 #include <MarioKartWii/Archive/ArchiveMgr.hpp>
 #include <MarioKartWii/RKNet/RKNetController.hpp>
 #include <core/rvl/OS/OS.hpp>
-#if defined(TEST) || defined(PROD)
+#if defined(PROD)
 #include <Security/BinVerifier.hpp>
 #endif
 
 namespace RetroRewind {
 
 void *GetCustomKartParam(ArchiveMgr *archive, ArchiveSource type, const char *name, u32 *length) {
-#if defined(TEST) || defined(PROD)
+#if defined(PROD)
     AntiCheat::VerifyBinFile(name);
 #endif
     return archive->GetFile(type, name, length);
@@ -42,7 +42,7 @@ void *GetCustomItemSlot(ArchiveMgr *archive, ArchiveSource type, const char *nam
         name = "ItemSlot.bin";
     }
 
-#if defined(TEST) || defined(PROD)
+#if defined(PROD)
     AntiCheat::VerifyBinFile(name);
 #endif
 

--- a/PulsarEngine/UI/PlayerCount.cpp
+++ b/PulsarEngine/UI/PlayerCount.cpp
@@ -362,7 +362,7 @@ void hook_ServerBrowserFree(ServerBrowser sb) {
 }
 
 void hook_DWC_SetReportLevel(u32 level) {
-#if defined(TEST) || defined(PROD)
+#ifndef PROD
     DWC_SetReportLevel(0xffffffff);
 #else
     DWC_SetReportLevel(level);


### PR DESCRIPTION
The changes in https://github.com/Retro-Rewind-Team/rr-pulsar/commit/02314182fbbbe370b605c092ad726a91504cb676 prevent anyone else from compiling test builds. Anything in Security should not be accessed on builds other than prod.